### PR TITLE
Feature/add saq3 specific data retrieval

### DIFF
--- a/Horiba.Sdk/Calculations/Stitching/ISpectraStich.cs
+++ b/Horiba.Sdk/Calculations/Stitching/ISpectraStich.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Horiba.Sdk.Core.Stitching
+{
+    /// <summary>
+    /// Stitches multiple spectra into a single spectrum.
+    /// </summary>
+    public interface ISpectraStitch
+    {
+        /// <summary>
+        /// Stitches this stitch with another stitch.
+        /// </summary>
+        ISpectraStitch StitchWith(ISpectraStitch otherStitch);
+
+        /// <summary>
+        /// Returns the raw data of the stitched spectra.
+        /// Python-compatible shape: [x, [y]]
+        /// </summary>
+        object StitchedSpectra();
+    }
+}

--- a/Horiba.Sdk/Calculations/Stitching/LabSpec6SpectraStitch.cs
+++ b/Horiba.Sdk/Calculations/Stitching/LabSpec6SpectraStitch.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Horiba.Sdk.Core.Internal;
+
+namespace Horiba.Sdk.Core.Stitching
+{
+    /// <summary>
+    /// Stitches a list of spectra using a weighted average as in LabSpec6.
+    /// 
+    /// Python parity:
+    /// - Each spectrum is shaped as [x, y] (no extra nesting around y).
+    /// - The stitched spectrum is returned as [x_stitched, y_stitched].
+    /// - Assumes x arrays are ordered (the Python version does not sort).
+    /// - Throws if there is no overlap.
+    /// - Computes weights A and B linearly over the overlap and combines y elementwise.
+    ///   (Assumes the two overlap ranges have the same number of samples, as in the Python.)
+    /// </summary>
+    public sealed class LabSpec6SpectraStitch : ISpectraStitch
+    {
+        // Stored as Python-compatible raw shape: [x, y]
+        private readonly List<object> _stitchedSpectrum;
+
+        /// <summary>
+        /// Construct from a list of spectra, each in Python-compatible shape: [x, y].
+        /// Example (C#):
+        /// var spectra = new List&lt;List&lt;object&gt;&gt;
+        /// {
+        ///     new() { x1, y1 },
+        ///     new() { x2, y2 },
+        /// };
+        /// </summary>
+        public LabSpec6SpectraStitch(List<List<object>> spectraList)
+        {
+            if (spectraList == null || spectraList.Count == 0)
+                throw new ArgumentException("spectraList must contain at least one spectrum.");
+
+            var stitched = spectraList[0];
+
+            for (int i = 1; i < spectraList.Count; i++)
+                stitched = StitchSpectra(stitched, spectraList[i]);
+
+            _stitchedSpectrum = stitched;
+        }
+
+        public ISpectraStitch StitchWith(ISpectraStitch otherStitch)
+        {
+            if (otherStitch is not LabSpec6SpectraStitch other)
+                throw new ArgumentException("otherStitch must be a LabSpec6SpectraStitch for exact parity.");
+
+            var combined = StitchSpectra(
+                (List<object>)this.StitchedSpectra(),
+                (List<object>)other.StitchedSpectra()
+            );
+
+            return new LabSpec6SpectraStitch(new List<List<object>> { combined });
+        }
+
+        public object StitchedSpectra() => _stitchedSpectrum;
+
+        // ---------- Core algorithm (parity with Python) ----------
+
+        private static List<object> StitchSpectra(List<object> spectrum1Raw, List<object> spectrum2Raw)
+        {
+            // Unpack Python-like shape: [x, y]
+            var x1 = ToDoubleArray(spectrum1Raw[0]);
+            var y1 = ToDoubleArray(spectrum1Raw[1]);
+
+            var x2 = ToDoubleArray(spectrum2Raw[0]);
+            var y2 = ToDoubleArray(spectrum2Raw[1]);
+
+            if (x1.Length == 0 || x2.Length == 0)
+                throw new ArgumentException("Spectra must contain at least one x/y pair.");
+
+            // Overlap region (assumes x are ordered; no sorting in Python version)
+            double overlapStart = Math.Max(x1[0], x2[0]);
+            double overlapEnd   = Math.Min(x1[x1.Length - 1], x2[x2.Length - 1]);
+
+            if (overlapStart >= overlapEnd)
+                throw new InvalidOperationException(
+                    $"No overlapping region between spectra: [{x1[0]}, {x1[x1.Length - 1]}] and [{x2[0]}, {x2[x2.Length - 1]}]");
+
+            // Masks on both spectra (inclusive)
+            var (x1Overlap, y1Overlap) = WhereXY(x1, y1, v => v >= overlapStart && v <= overlapEnd);
+            var (x2Overlap, y2Overlap) = WhereXY(x2, y2, v => v >= overlapStart && v <= overlapEnd);
+
+            // The original NumPy code multiplies arrays elementwise.
+            // That implies x1_overlap and x2_overlap have the same length in your data.
+            if (x1Overlap.Length != x2Overlap.Length)
+                throw new InvalidOperationException(
+                    "Overlap sample counts differ between spectra, which the original NumPy code would fail on. " +
+                    $"Got x1_overlap={x1Overlap.Length}, x2_overlap={x2Overlap.Length}.");
+
+            // Compute weights A, B over the overlap [overlapStart, overlapEnd]
+            double denom = (overlapEnd - overlapStart);
+            if (denom == 0.0)
+                throw new InvalidOperationException("Degenerate overlap (start equals end).");
+
+            var A = new double[x1Overlap.Length];
+            var B = new double[x2Overlap.Length];
+
+            for (int i = 0; i < x1Overlap.Length; i++)
+                A[i] = (x1Overlap[i] - overlapStart) / denom;
+
+            for (int i = 0; i < x2Overlap.Length; i++)
+                B[i] = (overlapEnd - x2Overlap[i]) / denom;
+
+            // y_stitched = (y1_overlap * A + y2_overlap * B) / (A + B)
+            var yStitchedOverlap = new double[x1Overlap.Length];
+            for (int i = 0; i < yStitchedOverlap.Length; i++)
+            {
+                double sum = A[i] + B[i];
+                // In theory sum > 0 inside the overlap; guard against float quirks.
+                if (sum == 0.0)
+                {
+                    // Fallback: average (mirrors the intuitive limit case)
+                    yStitchedOverlap[i] = 0.5 * (y1Overlap[i] + y2Overlap[i]);
+                }
+                else
+                {
+                    yStitchedOverlap[i] = (y1Overlap[i] * A[i] + y2Overlap[i] * B[i]) / sum;
+                }
+            }
+
+            // Before overlap: take from spectrum 1 (strictly before start)
+            var (xBefore, yBefore) = WhereXY(x1, y1, v => v < overlapStart);
+
+            // After overlap: take from spectrum 2 (strictly after end)
+            var (xAfter, yAfter) = WhereXY(x2, y2, v => v > overlapEnd);
+
+            // Concatenate like Python:
+            // x_stitched = [x_before, x1_overlap, x_after]
+            // y_stitched = [y_before, y_stitched_overlap, y_after]
+            var xStitched = Concat3(xBefore, x1Overlap, xAfter);
+            var yStitchedFinal = Concat3(yBefore, yStitchedOverlap, yAfter);
+
+            // Return in Python-compatible shape: [x_stitched, y_stitched]
+            return new List<object>
+            {
+                xStitched.ToList(),
+                yStitchedFinal.ToList()
+            };
+        }
+
+        // ---------- Helpers ----------
+
+        private static double[] ToDoubleArray(object o)
+        {
+            if (o is IEnumerable<double> ed) return ed.ToArray();
+            throw new ArgumentException("Expected a List<double> for x or y.");
+        }
+
+        private static (double[] xs, double[] ys) WhereXY(double[] x, double[] y, Func<double, bool> predicate)
+        {
+            var xs = new List<double>();
+            var ys = new List<double>();
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (predicate(x[i]))
+                {
+                    xs.Add(x[i]);
+                    ys.Add(y[i]);
+                }
+            }
+            return (xs.ToArray(), ys.ToArray());
+        }
+
+        private static double[] Concat3(double[] a, double[] b, double[] c)
+        {
+            return NumpyShims.Concat(NumpyShims.Concat(a, b), c);
+        }
+    }
+}

--- a/Horiba.Sdk/Calculations/Stitching/LinearSpectraStitch.cs
+++ b/Horiba.Sdk/Calculations/Stitching/LinearSpectraStitch.cs
@@ -1,35 +1,170 @@
-﻿//namespace Horiba.Sdk.Calculations.Stitching;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Horiba.Sdk.Core.Internal;
 
-//public class LinearSpectraStitch(List<XYData>[] data) : SpectraStitch(data)
-//{
-//    public override List<XYData> Stitch()
-//    {
-//        var stitched = new List<XYData>();
+namespace Horiba.Sdk.Core.Stitching
+{
+    /// <summary>
+    /// Stitches a list of spectra using a linear model.
+    /// 
+    /// Input/Output shape parity with Python:
+    /// - A single spectrum is represented as [x, [y]]
+    ///   where x : List&lt;double&gt;, and [y] is a List containing one List&lt;double&gt;.
+    /// - The stitched result is returned as the same shape: [x_combined, [y_combined]].
+    /// 
+    /// For convenience, the constructor accepts a list of such spectra.
+    /// </summary>
+    public sealed class LinearSpectraStitch : ISpectraStitch
+    {
+        // Stored as Python-compatible raw shape: [x, [y]]
+        // x = List<double>, [y] = List<List<double>> with a single inner list
+        private readonly List<object> _stitchedSpectrum;
 
-//        var orderedData = Data.Select(d => d.OrderBy(xy => xy.X).ToList()).ToArray();
+        /// <summary>
+        /// Construct from a list of spectra in Python-compatible shape: each spectrum = [x, [y]].
+        /// Example (C#):
+        /// var spectra = new List&lt;List&lt;object&gt;&gt;
+        /// {
+        ///     new() { x1, new List&lt;List&lt;double&gt;&gt; { y1 } },
+        ///     new() { x2, new List&lt;List&lt;double&gt;&gt; { y2 } },
+        /// };
+        /// </summary>
+        public LinearSpectraStitch(List<List<object>> spectraList)
+        {
+            if (spectraList == null || spectraList.Count == 0)
+                throw new ArgumentException("spectraList must contain at least one spectrum.");
 
-//        for (var i = 0; i < orderedData.Length - 1; i++)
-//        {
-//            var spectrum1 = i == 0 ? orderedData[i] : stitched;
-//            var spectrum2 = orderedData[i + 1];
+            // Start with the first spectrum as stitched base
+            var stitched = spectraList[0];
 
-//            var overlapStart = Math.Max(spectrum1[0].X, spectrum2[0].X);
-//            var overlapEnd = Math.Min(spectrum1[^1].X, spectrum2[^1].X);
+            for (int i = 1; i < spectraList.Count; i++)
+                stitched = StitchSpectra(stitched, spectraList[i]);
 
-//            var newStitched = new List<XYData>();
+            _stitchedSpectrum = stitched;
+        }
 
-//            newStitched.AddRange(spectrum1.Where(d => d.X < overlapStart));
+        public ISpectraStitch StitchWith(ISpectraStitch otherStitch)
+        {
+            if (otherStitch is not LinearSpectraStitch other)
+                throw new ArgumentException("otherStitch must be a LinearSpectraStitch for exact parity.");
 
-//            var spectrum1Overlapped = spectrum1.Where(d => d.X >= overlapStart).ToArray();
-//            var spectrum2Overlapped = spectrum2.Where(d => d.X <= overlapEnd).ToArray();
+            var combined = StitchSpectra(
+                (List<object>)this.StitchedSpectra(),
+                (List<object>)other.StitchedSpectra()
+            );
 
-//            newStitched.AddRange(spectrum1Overlapped.Select((d, index) => new XYData(d.X, (d.Y + spectrum2Overlapped[index].Y) / 2)));
+            return new LinearSpectraStitch(new List<List<object>> { combined });
+        }
 
-//            newStitched.AddRange(spectrum2.Where(d => d.X > overlapEnd));
+        public object StitchedSpectra() => _stitchedSpectrum;
 
-//            stitched = newStitched;
-//        }
+        // ---- Implementation mirroring the Python algorithm ----
 
-//        return stitched;
-//    }
-//}
+        private static List<object> StitchSpectra(List<object> spectrum1Raw, List<object> spectrum2Raw)
+        {
+            // Unpack Python-like shape: [x, [y]]
+            var x1 = ToDoubleArray(spectrum1Raw[0]);
+            var y1 = ToInnerYArray(spectrum1Raw[1]);
+
+            var x2 = ToDoubleArray(spectrum2Raw[0]);
+            var y2 = ToInnerYArray(spectrum2Raw[1]);
+
+            // Sort while maintaining x-y correspondence
+            var sort1 = NumpyShims.ArgSort(x1);
+            var sort2 = NumpyShims.ArgSort(x2);
+
+            var x1Sorted = NumpyShims.Take(x1, sort1);
+            var y1Sorted = NumpyShims.Take(y1, sort1);
+
+            var x2Sorted = NumpyShims.Take(x2, sort2);
+            var y2Sorted = NumpyShims.Take(y2, sort2);
+
+            // Overlap region
+            double x1Min = x1Sorted[0], x1Max = x1Sorted[x1Sorted.Length - 1];
+            double x2Min = x2Sorted[0], x2Max = x2Sorted[x2Sorted.Length - 1];
+
+            double overlapStart = Math.Max(x1Min, x2Min);
+            double overlapEnd   = Math.Min(x1Max, x2Max);
+
+            if (overlapStart >= overlapEnd)
+                throw new InvalidOperationException(
+                    $"No overlapping region between spectra: [{x1Min}, {x1Max}] and [{x2Min}, {x2Max}]");
+
+            // Masks on sorted arrays (inclusive)
+            var mask1 = BuildInclusiveMask(x1Sorted, overlapStart, overlapEnd);
+            var mask2 = BuildInclusiveMask(x2Sorted, overlapStart, overlapEnd);
+
+            // Interpolate y2 onto x1 in overlap region
+            var x1Overlap = NumpyShims.Mask(x1Sorted, mask1);
+            var x2Overlap = NumpyShims.Mask(x2Sorted, mask2);
+            var y2Overlap = NumpyShims.Mask(y2Sorted, mask2);
+
+            var y2Interp = NumpyShims.Interp(x1Overlap, x2Overlap, y2Overlap);
+
+            // Average overlap
+            var y1Overlap = NumpyShims.Mask(y1Sorted, mask1);
+            var yCombinedOverlap = new double[y1Overlap.Length];
+            for (int i = 0; i < yCombinedOverlap.Length; i++)
+                yCombinedOverlap[i] = 0.5 * (y1Overlap[i] + y2Interp[i]);
+
+            // Combine non-overlap + overlap (order mirrors Python)
+            var xNonOverlap1 = NumpyShims.Mask(x1Sorted, NumpyShims.Not(mask1));
+            var yNonOverlap1 = NumpyShims.Mask(y1Sorted, NumpyShims.Not(mask1));
+
+            var xNonOverlap2 = NumpyShims.Mask(x2Sorted, NumpyShims.Not(mask2));
+            var yNonOverlap2 = NumpyShims.Mask(y2Sorted, NumpyShims.Not(mask2));
+
+            var xCombined = NumpyShims.Concat(
+                NumpyShims.Concat(xNonOverlap1, x1Overlap),
+                xNonOverlap2
+            );
+            var yCombined = NumpyShims.Concat(
+                NumpyShims.Concat(yNonOverlap1, yCombinedOverlap),
+                yNonOverlap2
+            );
+
+            // Final sort by x
+            var sortIdx = NumpyShims.ArgSort(xCombined);
+            xCombined = NumpyShims.Take(xCombined, sortIdx);
+            yCombined = NumpyShims.Take(yCombined, sortIdx);
+
+            // Return in Python-compatible shape: [xCombined, [yCombined]]
+            return new List<object>
+            {
+                xCombined.ToList(),
+                new List<List<double>> { yCombined.ToList() }
+            };
+        }
+
+        private static bool[] BuildInclusiveMask(double[] x, double start, double end)
+        {
+            var m = new bool[x.Length];
+            for (int i = 0; i < x.Length; i++)
+                m[i] = (x[i] >= start) && (x[i] <= end);
+            return m;
+        }
+
+        // ---- Helpers to unpack Python-like shapes ----
+
+        private static double[] ToDoubleArray(object o)
+        {
+            if (o is IEnumerable<double> ed) return ed.ToArray();
+            throw new ArgumentException("Expected a List<double> for x.");
+        }
+
+        /// <summary>
+        /// Expects [y] (a list containing one List<double>) and returns the inner List<double> as array.
+        /// </summary>
+        private static double[] ToInnerYArray(object o)
+        {
+            if (o is IEnumerable<IEnumerable<double>> outer)
+            {
+                var first = outer.FirstOrDefault();
+                if (first is null) return Array.Empty<double>();
+                return first.ToArray();
+            }
+            throw new ArgumentException("Expected a List<List<double>> for [y].");
+        }
+    }
+}

--- a/Horiba.Sdk/Calculations/Stitching/NumpyShims.cs
+++ b/Horiba.Sdk/Calculations/Stitching/NumpyShims.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Horiba.Sdk.Core.Internal
+{
+    internal static class NumpyShims
+    {
+        /// <summary>
+        /// Returns indices that would sort the array ascending (stable).
+        /// </summary>
+        public static int[] ArgSort(double[] values)
+        {
+            return Enumerable.Range(0, values.Length)
+                             .OrderBy(i => values[i])
+                             .ToArray();
+        }
+
+        /// <summary>
+        /// Take array elements by index array.
+        /// </summary>
+        public static double[] Take(double[] values, int[] indices)
+        {
+            var r = new double[indices.Length];
+            for (int i = 0; i < indices.Length; i++)
+                r[i] = values[indices[i]];
+            return r;
+        }
+
+        /// <summary>
+        /// Boolean mask selection (true keeps element).
+        /// </summary>
+        public static double[] Mask(double[] values, bool[] mask)
+        {
+            var list = new List<double>(values.Length);
+            for (int i = 0; i < values.Length; i++)
+                if (mask[i]) list.Add(values[i]);
+            return list.ToArray();
+        }
+
+        /// <summary>
+        /// Logical NOT of mask.
+        /// </summary>
+        public static bool[] Not(bool[] mask)
+        {
+            var r = new bool[mask.Length];
+            for (int i = 0; i < mask.Length; i++) r[i] = !mask[i];
+            return r;
+        }
+
+        /// <summary>
+        /// Concatenate two arrays.
+        /// </summary>
+        public static double[] Concat(double[] a, double[] b)
+        {
+            var r = new double[a.Length + b.Length];
+            Array.Copy(a, 0, r, 0, a.Length);
+            Array.Copy(b, 0, r, a.Length, b.Length);
+            return r;
+        }
+
+        /// <summary>
+        /// NumPy-like interp: piecewise linear, clamps outside xp to fp edges.
+        /// Assumes xp is strictly increasing.
+        /// </summary>
+        public static double[] Interp(double[] x, double[] xp, double[] fp)
+        {
+            var y = new double[x.Length];
+
+            // Edge clamps
+            double xp0 = xp[0], xpN = xp[xp.Length - 1];
+            double fp0 = fp[0], fpN = fp[fp.Length - 1];
+
+
+            for (int i = 0; i < x.Length; i++)
+            {
+                double xi = x[i];
+
+                if (xi <= xp0) { y[i] = fp0; continue; }
+                if (xi >= xpN) { y[i] = fpN; continue; }
+
+                // Binary search for right interval [j-1, j]
+                int j = Array.BinarySearch(xp, xi);
+                if (j >= 0)
+                {
+                    // Exact match
+                    y[i] = fp[j];
+                    continue;
+                }
+
+                j = ~j; // first index greater than xi
+                int j0 = j - 1;
+                int j1 = j;
+
+                double x0 = xp[j0], x1 = xp[j1];
+                double y0 = fp[j0], y1 = fp[j1];
+
+                double t = (xi - x0) / (x1 - x0);
+                y[i] = y0 + t * (y1 - y0);
+            }
+
+            return y;
+        }
+    }
+}

--- a/Horiba.Sdk/Calculations/Stitching/SimpleCutSpectraStitch.cs
+++ b/Horiba.Sdk/Calculations/Stitching/SimpleCutSpectraStitch.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Horiba.Sdk.Core.Internal;
+
+namespace Horiba.Sdk.Core.Stitching
+{
+    /// <summary>
+    /// Stitches a list of spectra by always keeping the values from the next spectrum in the overlap region.
+    /// 
+    /// WARNING: Produces a stitched spectrum with "stairs".
+    /// 
+    /// Python parity:
+    /// - Each spectrum is shaped as [x, y] (NOTE: no extra nesting around y).
+    /// - The stitched spectrum is returned as [x_stitched, y_stitched].
+    /// - Assumes x arrays are ordered (Python version does not sort).
+    /// - Throws if there is no overlap.
+    /// </summary>
+    public sealed class SimpleCutSpectraStitch : ISpectraStitch
+    {
+        // Stored as Python-compatible raw shape: [x, y]
+        private readonly List<object> _stitchedSpectrum;
+
+        /// <summary>
+        /// Construct from a list of spectra, each in Python-compatible shape: [x, y].
+        /// Example (C#):
+        /// var spectra = new List&lt;List&lt;object&gt;&gt;
+        /// {
+        ///     new() { x1, y1 },
+        ///     new() { x2, y2 },
+        /// };
+        /// </summary>
+        public SimpleCutSpectraStitch(List<List<object>> spectraList)
+        {
+            if (spectraList == null || spectraList.Count == 0)
+                throw new ArgumentException("spectraList must contain at least one spectrum.");
+
+            var stitched = spectraList[0];
+
+            for (int i = 1; i < spectraList.Count; i++)
+                stitched = StitchSpectra(stitched, spectraList[i]);
+
+            _stitchedSpectrum = stitched;
+        }
+
+        public ISpectraStitch StitchWith(ISpectraStitch otherStitch)
+        {
+            if (otherStitch is not SimpleCutSpectraStitch other)
+                throw new ArgumentException("otherStitch must be a SimpleCutSpectraStitch for exact parity.");
+
+            var combined = StitchSpectra(
+                (List<object>)this.StitchedSpectra(),
+                (List<object>)other.StitchedSpectra()
+            );
+
+            return new SimpleCutSpectraStitch(new List<List<object>> { combined });
+        }
+
+        public object StitchedSpectra() => _stitchedSpectrum;
+
+        // ---------- Core algorithm (parity with Python) ----------
+
+        private static List<object> StitchSpectra(List<object> spectrum1Raw, List<object> spectrum2Raw)
+        {
+            // Unpack Python-like shape: [x, y]
+            var x1 = ToDoubleArray(spectrum1Raw[0]);
+            var y1 = ToDoubleArray(spectrum1Raw[1]);
+
+            var x2 = ToDoubleArray(spectrum2Raw[0]);
+            var y2 = ToDoubleArray(spectrum2Raw[1]);
+
+            if (x1.Length == 0 || x2.Length == 0)
+                throw new ArgumentException("Spectra must contain at least one x/y pair.");
+
+            // Overlap region (assumes x are ordered; no sorting in Python version)
+            double overlapStart = Math.Max(x1[0], x2[0]);
+            double overlapEnd   = Math.Min(x1[x1.Length - 1], x2[x2.Length - 1]);
+
+            if (overlapStart >= overlapEnd)
+                throw new InvalidOperationException($"No overlapping region between spectra: [{x1[0]}, {x1[x1.Length - 1]}] and [{x2[0]}, {x2[x2.Length - 1]}]");
+
+            // From spectrum 2, take the overlap region (mask2)
+            var (x2Overlap, y2Overlap) = WhereXY(x2, y2, v => v >= overlapStart && v <= overlapEnd);
+
+            // From spectrum 1, take values strictly before overlapStart
+            var (x1Before, y1Before) = WhereXY(x1, y1, v => v < overlapStart);
+
+            // From spectrum 2, take values strictly after overlapEnd
+            var (x2After, y2After) = WhereXY(x2, y2, v => v > overlapEnd);
+
+            // Concatenate in the same order as Python:
+            // x_stitched = [x1_before_overlap, x2_overlap, x2_after_overlap]
+            // y_stitched = [y1_before_overlap, y2_overlap, y2_after_overlap]
+            var xStitched = Concat3(x1Before, x2Overlap, x2After);
+            var yStitched = Concat3(y1Before, y2Overlap, y2After);
+
+            // Return in Python-compatible shape: [x_stitched, y_stitched]
+            return new List<object>
+            {
+                xStitched.ToList(),
+                yStitched.ToList()
+            };
+        }
+
+        // ---------- Helpers ----------
+
+        private static double[] ToDoubleArray(object o)
+        {
+            if (o is IEnumerable<double> ed) return ed.ToArray();
+            throw new ArgumentException("Expected a List<double> for x or y.");
+        }
+
+        private static (double[] xs, double[] ys) WhereXY(double[] x, double[] y, Func<double, bool> predicate)
+        {
+            var xs = new List<double>();
+            var ys = new List<double>();
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (predicate(x[i]))
+                {
+                    xs.Add(x[i]);
+                    ys.Add(y[i]);
+                }
+            }
+            return (xs.ToArray(), ys.ToArray());
+        }
+
+        private static double[] Concat3(double[] a, double[] b, double[] c)
+        {
+            // Use existing shim for 2-way concat to keep consistency
+            return NumpyShims.Concat(NumpyShims.Concat(a, b), c);
+        }
+    }
+}

--- a/Horiba.Sdk/Commands/SpectrAcqCommands.cs
+++ b/Horiba.Sdk/Commands/SpectrAcqCommands.cs
@@ -127,10 +127,15 @@ internal record SaqIsDataAvailableCommand(int DeviceId)
     public int DeviceId { get; } = DeviceId;
 }
 
-internal record SaqGetAvailableDataCommand(int DeviceId)
-    : SpectrAcqDeviceCommand("saq3_getAvailableData", DeviceId)
+internal record SaqGetAvailableDataCommand(int DeviceId, string[]? Channels = null) 
+    : SpectrAcqDeviceCommand("saq3_getAvailableData", new Dictionary<string, object>
+    {
+        { "index", DeviceId },
+        { "channels", Channels ?? new[] { "current", "voltage", "ppd", "photon" } }
+    })
 {
     public int DeviceId { get; } = DeviceId;
+    public string[] Channels { get; } = Channels ?? new[] { "current", "voltage", "ppd", "photon" };
 }
 
 internal record SaqForceTriggerCommand(int DeviceId)

--- a/Horiba.Sdk/Devices/SpectrAcqDevice.cs
+++ b/Horiba.Sdk/Devices/SpectrAcqDevice.cs
@@ -265,22 +265,29 @@ public sealed record SpectrAcqDevice(
             await Communicator.SendWithResponseAsync(new SaqIsDataAvailableCommand(DeviceId), cancellationToken);
         return (bool)result.Results["isDataAvailable"];
     }
+    
 
     /// <summary>
     /// Retrieves available acquisition data of the SAQ by sending the saq3_getAvailableData command
     /// </summary>
+    /// <param name="channels">Optional list of channels to read data from. Supported channels: "current", "voltage", "ppd", "photon". If not provided, data for all channels will be returned.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     public async Task<SaqData> GetAvailableDataAsync(
+        string[]? channels = null,
         CancellationToken cancellationToken = default)
     {
+        // Use explicit default values if channels is null
+        channels ??= new[] { "current", "voltage", "ppd", "photon" };
+    
         var result =
-            await Communicator.SendWithResponseAsync(new SaqGetAvailableDataCommand(DeviceId), cancellationToken);
+            await Communicator.SendWithResponseAsync(new SaqGetAvailableDataCommand(DeviceId, channels), cancellationToken);
         string jsonData = JsonConvert.SerializeObject(result.Results, Formatting.None);
         SaqData data = JsonConvert.DeserializeObject<SaqData>(jsonData);
         return data;
     }
 
+    
     /// <summary>
     /// Forces the trigger of the SAQ by sending the saq3_forceTrigger command
     /// </summary>

--- a/Horiba.Sdk/Horiba.Sdk.csproj
+++ b/Horiba.Sdk/Horiba.Sdk.csproj
@@ -16,9 +16,9 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryType>git</RepositoryType>
 
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <AssemblyVersion>1.0.0</AssemblyVersion>
-        <FileVersion>1.3.0</FileVersion>
+        <FileVersion>1.4.0</FileVersion>
         <PackageTags>horiba sdk ezspec monochromator ccd spectracq3</PackageTags>
         <PackageReleaseNotes>Initial pipeline deployment</PackageReleaseNotes>
 


### PR DESCRIPTION
This pull request introduces a new, extensible spectra stitching framework with Python parity, and refactors the codebase to add three concrete stitching algorithms, utility shims for NumPy-like operations, and a more flexible command for available data retrieval. The changes collectively enable different methods for combining spectra, each matching the behavior and data shape conventions of the equivalent Python implementations.

### Spectra Stitching Framework

* Introduced the `ISpectraStitch` interface in `ISpectraStitch.cs`, defining a common contract for spectra stitching algorithms, including methods for stitching and retrieving stitched spectra in Python-compatible shapes.
* Added three concrete implementations:
  - `LinearSpectraStitch` for linear interpolation and averaging, supporting [x, [y]] shapes and sorting for Python parity.
  - `LabSpec6SpectraStitch` for weighted averaging as in LabSpec6, supporting [x, y] shapes and enforcing overlap constraints.
  - `SimpleCutSpectraStitch` for a "cut" approach, always taking the next spectrum's values in overlap regions, also supporting [x, y] shapes.

### Utility and Infrastructure

* Added `NumpyShims` in `NumpyShims.cs` to provide essential NumPy-like array operations (sorting, masking, concatenation, interpolation) for use in the stitching algorithms, ensuring code clarity and Python parity.

### Command Improvements

* Refactored `SaqGetAvailableDataCommand` to accept an optional `Channels` parameter, defaulting to a standard set if not provided, and updated its payload to use a dictionary for greater flexibility.